### PR TITLE
Fix issue #34: Navigation buttons stepping 2 images instead of 1

### DIFF
--- a/dist/slideshow-gallery.js
+++ b/dist/slideshow-gallery.js
@@ -141,12 +141,15 @@ try {
 
     // Add event listeners for arrow keys
     document.addEventListener('keydown', (event) => {
-        if (event.key === 'ArrowLeft') {
-            currentImageIndex = (currentImageIndex - 1 + lightboxImages.length) % lightboxImages.length
-            updateLightbox()
-        } else if (event.key === 'ArrowRight') {
-            currentImageIndex = (currentImageIndex + 1) % lightboxImages.length
-            updateLightbox()
+        // Only handle keyboard events, not synthetic events from button clicks
+        if (event.isTrusted) {
+            if (event.key === 'ArrowLeft') {
+                currentImageIndex = (currentImageIndex - 1 + lightboxImages.length) % lightboxImages.length
+                updateLightbox()
+            } else if (event.key === 'ArrowRight') {
+                currentImageIndex = (currentImageIndex + 1) % lightboxImages.length
+                updateLightbox()
+            }
         }
     })
 


### PR DESCRIPTION
This PR fixes issue #34 where the next and previous buttons step 2 images instead of 1.

The issue was caused by the keyboard event listener handling both keyboard events and synthetic events from button clicks. The fix ensures that only trusted keyboard events are handled by the keyboard event listener.

References #34